### PR TITLE
Added additional light patterns in the Cochise.h header

### DIFF
--- a/Software/include/Cochise.h
+++ b/Software/include/Cochise.h
@@ -1,0 +1,74 @@
+
+/* Some global variables for facilitating the red_and_green_curtain_lights_to_middle() function */
+uint8_t curtain_UpCounter = LED_PER_START_POS - 1;
+uint8_t curtain_DownCounter = LED_QTY_USED;
+bool curtain_LightToggle = false;
+
+/* Some global variables for facilitating the stack_lights_in_the_middle() function */
+uint8_t stack_UpCounter = LED_PER_START_POS - 1;
+uint8_t stack_DownCounter = LED_QTY_USED;
+uint8_t stack_LightStop = LED_PER_MID_POS - 1;
+uint32_t stack_color_pattern[] = {CRGB::Red, CRGB::White, CRGB::Green, CRGB::Gold};
+uint8_t stack_pattern_count = 0;
+bool stack_LightToggle = false;
+
+void red_and_green_curtain_lights_to_middle();                                  /* RED and GREEN "curtain" lights close from left and right and meet in the middle of the LED string */
+void stack_lights_in_the_middle();
+
+/* RED and GREEN "curtains" lights close from left and right and meet in the middle of the LED string */
+void red_and_green_curtain_lights_to_middle() {
+    // Every 25ms we'll update the LED pattern
+    EVERY_N_MILLISECONDS( 25 ) { 
+        if( curtain_UpCounter < LED_PER_MID_POS && curtain_LightToggle == false ) {
+            LED_ARR[ curtain_UpCounter++ ] = CRGB::Red;       // As long as the LED upCounter has not reached the middle of the LED string increment and turn the next light in the array RED 
+            LED_ARR[ curtain_DownCounter--] = CRGB::Red;      // Same condition as above but this walks in our LED pattern from the "farside" of the LED string in toward the middle
+        }
+        else if( curtain_UpCounter >= LED_PER_MID_POS && curtain_LightToggle == false ){
+            curtain_UpCounter = LED_PER_START_POS - 1;      // After reaching the middle we now want to start the pattern over so we send the counters back to the "far ends" of the LED string
+            curtain_DownCounter = LED_QTY_USED;             
+            curtain_LightToggle = true;                     // As we don't want to repeat the pattern with RED lights anymore (wouldn't be visible) we need to toggle our 'LightToggle' variable to 'change states'
+        }
+        else if( curtain_UpCounter < LED_PER_MID_POS && curtain_LightToggle == true){
+            LED_ARR[ curtain_UpCounter++ ] = CRGB::Green;   //As long as 
+            LED_ARR[ curtain_DownCounter--] = CRGB::Green;
+        }
+        else{
+            curtain_UpCounter = LED_PER_START_POS - 1;
+            curtain_DownCounter = LED_QTY_USED;
+            curtain_LightToggle = false;
+        }
+    }
+}
+
+void stack_lights_in_the_middle(){
+    
+    EVERY_N_MILLISECONDS(15){
+        if( stack_LightToggle == false ){
+            if( stack_UpCounter < stack_LightStop ){
+                LED_ARR[ stack_UpCounter ] = CRGB::Black;
+                LED_ARR[ stack_DownCounter ] = CRGB::Black;
+                stack_UpCounter++;
+                stack_DownCounter--;
+                LED_ARR[ stack_UpCounter ] = stack_color_pattern[stack_pattern_count];
+                LED_ARR[ stack_DownCounter ] = stack_color_pattern[stack_pattern_count];
+            }
+            else if( stack_UpCounter >= stack_LightStop ){
+                stack_UpCounter = LED_PER_START_POS - 1;
+                stack_DownCounter = LED_QTY_USED;
+                stack_pattern_count++;
+                stack_pattern_count = stack_pattern_count % 4;
+                stack_LightStop--;
+            }
+            if( stack_LightStop == 0 ){
+                stack_LightToggle = true;
+            }
+        }
+        if( stack_LightToggle == true ){
+            fadeToBlackBy(LED_ARR + LED_PER_START_POS, LED_QTY_USED - LED_PER_START_POS, 255);
+            stack_LightStop = LED_PER_MID_POS - 1;
+            stack_UpCounter = LED_PER_START_POS - 1;
+            stack_DownCounter = LED_QTY_USED;
+            stack_LightToggle = false;
+        }
+    }
+}

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -2,7 +2,7 @@
 /* 
     Author: Ryan Klassing 
     Date: 11/29/22
-    Version: */ #define BLYNK_FIRMWARE_VERSION "0.0.4" /*
+    Version: */ #define BLYNK_FIRMWARE_VERSION "0.0.26" /*
     Description:
         This is intended to run a small ESP32 based PCB that looks
         like a ghost, for simple/fun Christmas decotrations.  The
@@ -15,6 +15,17 @@
         on-board "ambiance" lighting, and will be manually soldered on to the external lighting cable).
 
     License: see "LICENSE" file
+
+    12/21/2022 - Cochise Push
+    Description:
+        Added light patterns "red_and_green_curtain_lights_to_middle" and "stack_lights_in_the_middle"
+        in "Cochise.h" file.  The main.cpp code was modified to call out these light patterns in the
+        christmas_patterns function list and to add #include of the Cochise.h file just below "[END]
+        HW Configuration Setup" section.  This placement ensures that #defines used by the functions
+        have been completed before Cochise.h inclusion. Lastly, modified LED_PER_START_POS from 2 to 10
+        and added LED_PER_MID_POS 60 which marks the mid-point of the LED string offset by the start
+        position.
+
 */
 
 /* ------------ [START] Early definitions for Blynk -------------- */
@@ -55,7 +66,8 @@
     #define LED_QTY_USED 110        //Actual QTY of lights in the strands --> USE THIS FOR LIGHT FUNCTIONS
     #define LED_RIGHT_EYE_POS 0     //Right Eye LED position in the LED array
     #define LED_LEFT_EYE_POS 1      //Left Eye LED position in the LED array
-    #define LED_PER_START_POS 2     //Starting array position for the peripheral LEDs
+    #define LED_PER_START_POS 10     //Starting array position for the peripheral LEDs
+    #define LED_PER_MID_POS 60       //Midpoint of the LED string (the strings are 100 LEDs, but these are offset by the 10 LEDs on the Ghost board which pushes the middle to 60)
     #define LED_MAX_BRIGHTNESS 255   //Maximum allowed brightness for the LEDs
     #define LED_FPS 60              //# of times to push an update to the LED color/brightness per second
     #define LED_PER_FADE_AMT 20     //Fade-in / Fade-out will be done in this increment
@@ -76,6 +88,10 @@
     uint8_t led_user_setting = false;
 
 /* -------------- [END] HW Configuration Setup -------------- */
+
+ /* ------------- [START] A place to include all of the 'individual contributors' header files of functions ------------- */
+    #include <Cochise.h>
+/* ------------- [END] A place to include all of the 'individual contributors' header files of functions ------------- */
 
 /* ------------ [START] Debug compile options -------------- */
     #define LOG_DEBUG true          //true = logging printed to terminal, false = no logging
@@ -179,7 +195,7 @@
     typedef void (*FunctionList[])();
 
     /* Update this array whenever new functions need to be added, and the led_handler will automatically loop through them */
-    FunctionList christmas_patterns = {fading_candy_cane, fading_christmas_spirit /*, rainbow_pattern, juggle_candy_cane, juggle_christmas_spirit, rotating_candy_cane, rotating_christmas_spirit*/};
+    FunctionList christmas_patterns = {stack_lights_in_the_middle, red_and_green_curtain_lights_to_middle/*fading_candy_cane, fading_christmas_spirit, rainbow_pattern, juggle_candy_cane, juggle_christmas_spirit, rotating_candy_cane, rotating_christmas_spirit*/};
 
     /* function list index to loop through the patterns */
     uint8_t christmas_patterns_idx = 0;


### PR DESCRIPTION
Added light patterns "red_and_green_curtain_lights_to_middle" and "stack_lights_in_the_middle"
in "Cochise.h" file.  The main.cpp code was modified to call out these light patterns in the
christmas_patterns function list and to add #include of the Cochise.h file just below "[END]
HW Configuration Setup" section.  This placement ensures that #defines used by the functions
have been completed before Cochise.h inclusion. Lastly, modified LED_PER_START_POS from 2 to 10
and added LED_PER_MID_POS 60 which marks the mid-point of the LED string offset by the start
position.